### PR TITLE
FIX: Deprecated use of Object::add_extension and has_extension

### DIFF
--- a/code/GoogleAnalyzer.php
+++ b/code/GoogleAnalyzer.php
@@ -37,14 +37,14 @@ class GoogleAnalyzer extends DataExtension {
 	public static function activate($profile = 'SiteConfig', $email = null, $password = null) {
 		
 		switch($profile) {
-			case 'SiteConfig': Object::add_extension('SiteConfig', 'GoogleConfig'); break;
+			case 'SiteConfig': SiteConfig::add_extension('GoogleConfig'); break;
 			default:
 				self::$profile_id = $profile;
 				self::$email = $email;
 				self::$password = $password;
 		}
 
-		Object::add_extension('SiteTree', 'GoogleAnalyzer');
+		SiteTree::add_extension('GoogleAnalyzer');
 	}
 
 	public function updateCMSFields(FieldList $fields) {

--- a/code/GoogleConfig.php
+++ b/code/GoogleConfig.php
@@ -31,7 +31,7 @@ class GoogleConfig extends DataExtension {
 	 *	@return String the config value
 	 **/
 	public static function get_google_config($key) {
-		if(class_exists('SiteConfig') && Object::has_extension('SiteConfig', 'GoogleConfig')) {
+		if(class_exists('SiteConfig') && SiteConfig::has_extension('GoogleConfig')) {
 			$config = SiteConfig::current_site_config();
 		}
 		switch($key) {

--- a/code/GoogleLogger.php
+++ b/code/GoogleLogger.php
@@ -31,11 +31,11 @@ class GoogleLogger extends Extension {
 		
 		switch($code) {
 			case null: self::$google_analytics_code = null; break;
-			case 'SiteConfig': Object::add_extension('SiteConfig', 'GoogleConfig'); break;
+			case 'SiteConfig': SiteConfig::add_extension('GoogleConfig'); break;
 			default: self::$google_analytics_code = $code;
 		}
 
-		Object::add_extension('ContentController', 'GoogleLogger');
+		ContentController::add_extension('GoogleLogger');
 
 		if(substr(GoogleAnalyzer::get_sapphire_version(), 0, 3) == '2.3') Director::add_callback(array("GoogleLogger","onAfterInit23"));
 	}


### PR DESCRIPTION
After updating to the recent 3.0.3 release, the JS snippet was not being added to my pages. I tracked this down to the line 34 of `GoogleConfig.php`: the condition `Object::has_extension('SiteConfig', 'GoogleConfig')`was not being evaluated as true.

Looking at Object class I’ve seen that Object::add_extension and has_extension are being [deprecated in SS 3.1](http://doc.silverstripe.org/framework/en/trunk/changelogs/3.1.0#upgrading), so I tried changing the above code to `SiteConfig::has_extension('GoogleConfig')` and it worked.

I don’t understand why these two functions are not working as expected in 3.0.3, so I’m not sure that this commit can be applied, but it’s the only way I’ve found to make the module work.

Hope it helps,
Juan
