### PR TITLE
Added support for Google Analytics campaigns via pretty and relevant SiteTree URLs.

### DIFF
--- a/code/GoogleCampaignRedirector.php
+++ b/code/GoogleCampaignRedirector.php
@@ -1,6 +1,10 @@
 <?php
 
 class GoogleCampaignRedirector extends RedirectorPage {
+	
+	/*
+	 * The standard campaign tracking codes available
+	 */
 	public static $db = array(
 		"CampaignSource" => "Text",
 		"CampaignMedium" => "Text",
@@ -9,6 +13,9 @@ class GoogleCampaignRedirector extends RedirectorPage {
 		"CampaignName" => "Text"
 	);
 	
+	/*
+	 * Typically, these won't form part of a menu.
+	 */
 	public static $defaults = array(
 		"ShowInMenus" => 0,
 		"ShowInSearch" => 0
@@ -17,20 +24,26 @@ class GoogleCampaignRedirector extends RedirectorPage {
 	public function getCMSFields(){
 		$fields = parent::getCMSFields();
 		$fields->addFieldToTab('Root.Main', new LiteralField("ga_heading", "<hr /><h2>Google Analytics Campaign Settings</h2>"));
+		//TODO: Add a description of the /meaning/ of these to help users (or link through to Google's docs?)
 		$fields->addFieldToTab('Root.Main', new TextField('CampaignSource'));
 		$fields->addFieldToTab('Root.Main', new TextField('CampaignMedium'));
 		$fields->addFieldToTab('Root.Main', new TextField('CampaignTerm'));
 		$fields->addFieldToTab('Root.Main', new TextField('CampaignContent'));
 		$fields->addFieldToTab('Root.Main', new TextField('CampaignName'));
-		
 		return $fields;
 	}
 	
+	/**
+	 * For a given request, get the GA-ready query string that can be appended
+	 */
 	public function getQueryString() {
+		//These three are required no matter what
 		$cs = urlencode($this->CampaignSource);
 		$cm = urlencode($this->CampaignMedium);
 		$cn = urlencode($this->CampaignName);
 		$ret = "utm_source=$cs&utm_medium=$cm&utm_campaign=$cn";
+		
+		//The next two are optional so let's only set them if there's a value there.
 		if($this->CampaignTerm){
 			$ct = urlencode($this->CampaignTerm);
 			$ret .= "&utm_term=$ct";
@@ -46,12 +59,17 @@ class GoogleCampaignRedirector extends RedirectorPage {
 class GoogleCampaignRedirector_Controller extends RedirectorPage_Controller {
 	
 	public function init() {
-		if($link = self::addQueryString($this->redirectionLink(),$this->getQueryString())) {
-			$this->redirect($link, 301);
+		//Override the redirector behaviour to point to the GA-enabled link
+		if($link = $this->redirectionLink()) {
+			$this->redirect(self::addQueryString($link,$this->getQueryString()), 301);
 			return;
 		}
 	}
 	
+	/**
+	 * Helper function to add a query string to a URL in different ways depending on
+	 * the original URL. I.e. avoid example.com?a=b&c=d?e=f&g=h
+	 */
 	public static function addQueryString($link, $query){
 		if(strpos("?", $link) === FALSE){
 			return "$link?$query";

--- a/code/GoogleCampaignRedirector.php
+++ b/code/GoogleCampaignRedirector.php
@@ -54,27 +54,31 @@ class GoogleCampaignRedirector extends RedirectorPage {
 		}
 		return $ret;
 	}
-}
-
-class GoogleCampaignRedirector_Controller extends RedirectorPage_Controller {
 	
-	public function init() {
-		//Override the redirector behaviour to point to the GA-enabled link
-		if($link = $this->redirectionLink()) {
-			$this->redirect(self::addQueryString($link,$this->getQueryString()), 301);
-			return;
+	/**
+	 * @override
+	 * @return the link with query string
+	 */
+	public function redirectionLink() {
+		if($link = parent::redirectionLink()) {
+			return self::addQueryString($link,$this->getQueryString());
 		}
+		return null;
 	}
 	
 	/**
 	 * Helper function to add a query string to a URL in different ways depending on
 	 * the original URL. I.e. avoid example.com?a=b&c=d?e=f&g=h
 	 */
-	public static function addQueryString($link, $query){
-		if(strpos("?", $link) === FALSE){
+	private static function addQueryString($link, $query){
+		if(strpos($link, "?") === FALSE){
 			return "$link?$query";
 		} else {
 			return "$link&$query";
 		}
 	}
+}
+
+class GoogleCampaignRedirector_Controller extends RedirectorPage_Controller {
+	
 }

--- a/code/GoogleCampaignRedirector.php
+++ b/code/GoogleCampaignRedirector.php
@@ -1,0 +1,62 @@
+<?php
+
+class GoogleCampaignRedirector extends RedirectorPage {
+	public static $db = array(
+		"CampaignSource" => "Text",
+		"CampaignMedium" => "Text",
+		"CampaignTerm" => "Text",
+		"CampaignContent" => "Text",
+		"CampaignName" => "Text"
+	);
+	
+	public static $defaults = array(
+		"ShowInMenus" => 0,
+		"ShowInSearch" => 0
+	);
+	
+	public function getCMSFields(){
+		$fields = parent::getCMSFields();
+		$fields->addFieldToTab('Root.Main', new LiteralField("ga_heading", "<hr /><h2>Google Analytics Campaign Settings</h2>"));
+		$fields->addFieldToTab('Root.Main', new TextField('CampaignSource'));
+		$fields->addFieldToTab('Root.Main', new TextField('CampaignMedium'));
+		$fields->addFieldToTab('Root.Main', new TextField('CampaignTerm'));
+		$fields->addFieldToTab('Root.Main', new TextField('CampaignContent'));
+		$fields->addFieldToTab('Root.Main', new TextField('CampaignName'));
+		
+		return $fields;
+	}
+	
+	public function getQueryString() {
+		$cs = urlencode($this->CampaignSource);
+		$cm = urlencode($this->CampaignMedium);
+		$cn = urlencode($this->CampaignName);
+		$ret = "utm_source=$cs&utm_medium=$cm&utm_campaign=$cn";
+		if($this->CampaignTerm){
+			$ct = urlencode($this->CampaignTerm);
+			$ret .= "&utm_term=$ct";
+		}
+		if($this->CampaignContent){
+			$cc = urlencode($this->CampaignContent);
+			$ret .= "&utm_content=$cc";
+		}
+		return $ret;
+	}
+}
+
+class GoogleCampaignRedirector_Controller extends RedirectorPage_Controller {
+	
+	public function init() {
+		if($link = self::addQueryString($this->redirectionLink(),$this->getQueryString())) {
+			$this->redirect($link, 301);
+			return;
+		}
+	}
+	
+	public static function addQueryString($link, $query){
+		if(strpos("?", $link) === FALSE){
+			return "$link?$query";
+		} else {
+			return "$link&$query";
+		}
+	}
+}

--- a/tests/GoogleCampaignRedirectorTest.php
+++ b/tests/GoogleCampaignRedirectorTest.php
@@ -1,0 +1,14 @@
+<?php
+
+class GoogleCampaignRedirectorTest extends SapphireTest {
+	static $fixture_file = 'GoogleCampaignRedirectorTest.yml';
+	static $use_draft_site = true;
+
+	public function testCampaignUrlBuilding() {
+		$this->assertEquals("http://www.example.com/?a=b&utm_source=source&utm_medium=medium&utm_campaign=name&utm_term=term&utm_content=content", $this->objFromFixture('GoogleCampaignRedirector','witheverything')->redirectionLink());
+	}
+	
+	public function testPartialCampaignUrlBuilding() {
+		$this->assertEquals(Director::baseURL() . 'redirection-dest/?utm_source=source&utm_medium=medium&utm_campaign=name', $this->objFromFixture('GoogleCampaignRedirector','withminimalfields')->redirectionLink());
+	}
+}

--- a/tests/GoogleCampaignRedirectorTest.yml
+++ b/tests/GoogleCampaignRedirectorTest.yml
@@ -1,0 +1,23 @@
+Page:
+   dest:
+      Title: Redirection Dest
+      URLSegment: redirection-dest
+GoogleCampaignRedirector:
+   witheverything:
+      Title: Good External Redirect With All Fields
+      URLSegment: all-fields
+      RedirectionType: External
+      ExternalURL: http://www.example.com/?a=b
+      CampaignSource: source
+      CampaignMedium: medium
+      CampaignTerm: term
+      CampaignContent: content
+      CampaignName: name
+   withminimalfields:
+      Title: Good Internal Redirect With All Fields
+      URLSegment: minimal-fields
+      RedirectionType: Internal
+      LinkTo: =>Page.dest
+      CampaignSource: source
+      CampaignMedium: medium
+      CampaignName: name


### PR DESCRIPTION
## Preface
This may not be part of the road-map but I thought it was nevertheless Google Analytics related and useful (at least to me!). It sort of sits outside of the more 'general purpose' functionalities in the module at the moment. It is designed to avoid having to hack in redirects all over the place.

## Description
Added support for Google Analytics campaigns via pretty and relevant SiteTree URLs (i.e. as part of the standard site structure).

The GoogleCampaignRedirector is a first-stab implementation of enabling the user to use http://example.com/example to then redirect through to a predefined set of GA campaign information, e.g. http://example.com/actual-page?utm_source=123&utm_name=456[...]. Useful for where a nice url is needed, e.g. print materials being tracked as part of a campaign.