### PR TITLE
API 3.1 compatibility: Static configurable properties must be private and immutable.

### DIFF
--- a/code/GoogleAnalyzer.php
+++ b/code/GoogleAnalyzer.php
@@ -12,7 +12,7 @@ class GoogleAnalyzer extends DataExtension {
 	public static $email;
 	public static $password;
 
-	static $has_many = array(
+	private static $has_many = array(
 		'Events' => 'GoogleLogEvent',
 	);
 

--- a/code/GoogleCachedQuery.php
+++ b/code/GoogleCachedQuery.php
@@ -2,7 +2,7 @@
 
 class GoogleCachedQuery extends DataObject {
 
-	static $db = array(
+	private static $db = array(
 		'Hash' => 'Varchar(255)',
 		'Data' => 'Text',
 	);

--- a/code/GoogleConfig.php
+++ b/code/GoogleConfig.php
@@ -5,7 +5,7 @@
  */
 class GoogleConfig extends DataExtension {
 
-	static $db = array(
+	private static $db = array(
 		'GoogleAnalyticsCode' => 'Varchar',
 		'GoogleAnalyticsProfileId' => 'Varchar(255)',
 		'GoogleAnalyticsEmail' => 'Varchar',

--- a/code/GoogleLogEvent.php
+++ b/code/GoogleLogEvent.php
@@ -2,12 +2,12 @@
 
 class GoogleLogEvent extends DataObject {
 
-	static $db = array(
+	private static $db = array(
 		'Title' => 'Varchar',
 		'Description' => 'Text',
 	);
 
-	static $has_one = array(
+	private static $has_one = array(
 		'Page' => 'SiteTree',
 	);
 }


### PR DESCRIPTION
Static configurable properties (db, has_one, etc) are now private. See: http://doc.silverstripe.org/framework/en/3.1/changelogs/3.1.0#static-properties-are-immutable-and-private-you-must-use-config-api
