### PR TITLE
Fix bug that prevents dev/build running

### DIFF
--- a/code/GoogleLogger.php
+++ b/code/GoogleLogger.php
@@ -49,7 +49,11 @@ class GoogleLogger extends Extension {
 	}
 
 	public function onAfterInit() {
-		if($this->owner instanceof DevelopmentAdmin || $this->owner instanceof DatabaseAdmin) {
+		if(
+			$this->owner instanceof DevelopmentAdmin ||
+			$this->owner instanceof DatabaseAdmin ||
+			(class_exists('DevBuildController') && $this->owner instanceof DevBuildController)
+		) {
 			return;
 		}
 


### PR DESCRIPTION
This fix allows dev/build to run on fresh installs.

To reproduce the issue: (I've been able to reproduce this morning using 3.1.8)

```
composer create-project silverstripe/installer .
sake dev/build flush=all
composer require silverstripe-labs/googleanalytics
sake dev/build flush=all
```

The second dev/build will fail with the following error:

```
ERROR [User Error]: Couldn't run query:
SELECT DISTINCT "SiteConfig"."ClassName", "SiteConfig"."Created", "SiteConfig"."LastEdited", "SiteConfig"."Title", "SiteConfig"."Tagline", "SiteConfig"."Theme", "SiteConfig"."CanViewType", "SiteConfig"."CanEditType", "SiteConfig"."CanCreateTopLevelType", "SiteConfig"."GoogleAnalyticsCode", "SiteConfig"."GoogleAnalyticsProfileId", "SiteConfig"."GoogleAnalyticsEmail", "SiteConfig"."GoogleAnalyticsPassword", "SiteConfig"."UseGoogleUniversalSnippet", "SiteConfig"."ID", CASE WHEN "SiteConfig"."ClassName" IS NOT NULL THEN "SiteConfig"."ClassName" ELSE 'SiteConfig' END AS "RecordClassName"
FROM "SiteConfig"
LIMIT 1

Unknown column 'SiteConfig.GoogleAnalyticsCode' in 'field list'
IN GET /dev/build
```

Adding the additional `instanceof` check for the `DevBuildController` in `code/GoogleLogger.php` fixes this problem
