### PR TITLE
NEW Remove trailing slashes from tracked URLs

### DIFF
--- a/templates/GoogleAnalyticsJSSnippet.ss
+++ b/templates/GoogleAnalyticsJSSnippet.ss
@@ -1,15 +1,15 @@
-<% if UseGoogleUniversalSnippet %>
+<% if $UseGoogleUniversalSnippet %>
 (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
 (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
 m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
 ga('create', '$GoogleAnalyticsCode', 'auto');
-ga('send', 'pageview');
+ga('send', 'pageview', location.pathname.replace(/\\/+\$/, ''));
 <% else %>
 var _gaq = _gaq || [];
 _gaq.push(['_setAccount', '$GoogleAnalyticsCode']);
-_gaq.push(['_trackPageview']);
+_gaq.push(['_trackPageview', , location.pathname.replace(/\\/+\$/, '')]);
 
 (function() {
 	var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;


### PR DESCRIPTION
Remove the trailing slash from URLs. This solves the problem where Google Analytics will show different tracking for URLs if they have a trailing slash or not.

See https://developers.google.com/analytics/devguides/collection/analyticsjs/pages#modifying_page_urls for docs that detail `location.pathname` is what it relied on for this parameter

I haven't looked in detail whether it's "better" to have a trailing slash or not, but this is the simplest of the two (removing trailing slash vs adding a trailing slash) because extra logic is needed to determine if there's a file extension or not (which shouldn't have a trailing slash).
